### PR TITLE
Replace 'Svalbard And Jan Mayen' with 'Norway'

### DIFF
--- a/data/phone/countries.yml
+++ b/data/phone/countries.yml
@@ -1226,8 +1226,8 @@
   :country_code: "47"
   :national_dialing_prefix: None
   :char_2_code: None
-  :char_3_code: SJ
-  :name: Svalbard And Jan Mayen
+  :char_3_code: "NO"
+  :name: Norway
   :international_dialing_prefix: "0"
 "359": 
   :country_code: "359"


### PR DESCRIPTION
Svalbard And Jan Mayen are remote regions that are part of Norway. Given that most phone numbers starting with +47 will be in Norway it makes more sense to list Norway as the corresponding country.