### PR TITLE
Fix NZ area code validation

### DIFF
--- a/data/phone/countries.yml
+++ b/data/phone/countries.yml
@@ -637,7 +637,7 @@
   :char_3_code: NZ
   :name: New Zealand
   :international_dialing_prefix: "0"
-  :area_code: "[1-9]"
+  :area_code: "2[0-9]|3[0-9]|4|6|7|9"
 "855": 
   :country_code: "855"
   :national_dialing_prefix: "0"


### PR DESCRIPTION
Some NZ phone numbers have 10 digits after 021, which was not supported. This updated validation should match current NZ phone formats. It has been tested against the following numbers:

### Mobile Numbers (Start with 02X)

    021 234 5678 → One NZ (formerly Vodafone)

    022 987 6543 → 2degrees

    027 111 2222 → Spark

    029 876 5432 → TelstraClear (now One NZ)

    021 023 94067 → Similar to known number

### Landline Numbers (Start with 03, 04, 06, 07, or 09)

    03 477 4000 → Dunedin landline

    04 499 1234 → Wellington landline

    06 835 6789 → Napier landline

    07 571 9800 → Tauranga landline

    09 379 2000 → Auckland landline